### PR TITLE
Update TSLint to 3.2.0, Add TS Dependency

### DIFF
--- a/com.palantir.tslint/package.json
+++ b/com.palantir.tslint/package.json
@@ -1,8 +1,9 @@
 {
   "name": "eclipse-tslint",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "dependencies": {
-    "tslint": "3.0.0"
+    "tslint": "3.2.0",
+    "typescript": "1.7.5"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
@adidahiya Do we need a TypeScript dependency in here? There wasn't one, but it seemed to me that there should be with TSLint > 3.0